### PR TITLE
Adjust RedisConfig

### DIFF
--- a/src/main/java/tradingz/firstproject/config/RedisConfig.java
+++ b/src/main/java/tradingz/firstproject/config/RedisConfig.java
@@ -1,23 +1,86 @@
 package tradingz.firstproject.config;
 
+import io.lettuce.core.ClientOptions;
+import io.lettuce.core.SocketOptions;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.core.env.Environment;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.GenericToStringSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
+import java.time.Duration;
+
 @Configuration
 public class RedisConfig {
+    @Autowired
+    private Environment environment;
+
+    @Value("${cache.redis.host}")
+    private String redisHost;
+    @Value("${cache.redis.port}")
+    private int redisPort;
+    @Value("${cache.redis.time-to-live}")
+    private long redisCacheTtl;
+    @Value("${cache.redis.use-ssl}")
+    private boolean useSSL;
 
     @Bean
-    public RedisTemplate<String, String> redisTemplate(RedisConnectionFactory connectionFactory) {
+    public LettuceConnectionFactory redisConnectionFactory() {
+        final SocketOptions socketOptions = SocketOptions.builder().connectTimeout(Duration.ofSeconds(10)).build();
+        ClientOptions clientOptions = ClientOptions.builder()
+                .socketOptions(socketOptions)
+                .autoReconnect(true)
+                .disconnectedBehavior(ClientOptions.DisconnectedBehavior.REJECT_COMMANDS)
+                .build();
+
+        LettuceClientConfiguration.LettuceClientConfigurationBuilder clientConfigBuilder =
+                LettuceClientConfiguration.builder()
+                        .commandTimeout(Duration.ofSeconds(10))
+                        .clientOptions(clientOptions);
+
+        if (useSSL) clientConfigBuilder.useSsl();
+
+        RedisStandaloneConfiguration redisConf = new RedisStandaloneConfiguration();
+        redisConf.setHostName(redisHost);
+        redisConf.setPort(redisPort);
+        redisConf.setUsername(environment.getProperty("cache.redis.username"));
+        redisConf.setPassword(environment.getProperty("cache.redis.password"));
+
+        return new LettuceConnectionFactory(redisConf, clientConfigBuilder.build());
+    }
+
+    @Bean
+    public RedisCacheConfiguration cacheConfiguration() {
+        return RedisCacheConfiguration.defaultCacheConfig()
+                .entryTtl(Duration.ofMillis(redisCacheTtl))
+                .disableCachingNullValues();
+    }
+
+    @Bean
+    public RedisCacheManager cacheManager() {
+        return RedisCacheManager.builder(redisConnectionFactory())
+                .cacheDefaults(cacheConfiguration())
+                //.transactionAware()
+                .build();
+    }
+
+    @Bean
+    @Primary
+    public RedisTemplate<String, String> redisTemplate() {
         RedisTemplate<String, String> template = new RedisTemplate<>();
-        template.setConnectionFactory(connectionFactory);
-        template.setDefaultSerializer(new StringRedisSerializer());
+        template.setConnectionFactory(redisConnectionFactory());
+        template.setKeySerializer(new StringRedisSerializer());
         template.setValueSerializer(new GenericToStringSerializer<>(String.class));
-        template.setHashKeySerializer(new StringRedisSerializer());
-        template.setHashValueSerializer(new StringRedisSerializer());
         return template;
     }
 }

--- a/src/main/java/tradingz/firstproject/controllers/UserController.java
+++ b/src/main/java/tradingz/firstproject/controllers/UserController.java
@@ -26,7 +26,6 @@ public class UserController {
     }
 
     @Autowired
-    @Qualifier("redisTemplate")
     private RedisTemplate<String, String> userTemplate;
     private final ObjectMapper objectMapper = new ObjectMapper();
     @QueryMapping

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,6 +4,10 @@ spring.datasource.username=root
 spring.datasource.password=Minh.25012002
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 #spring.jpa.show-sql: true
-spring.redis.host=localhost
-spring.redis.port=6379
+
+#Redis
+cache.redis.host=localhost
+cache.redis.port=6379
+cache.redis.time-to-live=60000
+cache.redis.use-ssl=false
 


### PR DESCRIPTION
- Cấu hình lại RedisConfig
- Phần @Bean @Primary (trong RedisConfig) đang thay thế cho việc dùng @Qualifier, tại vì chương trình đang tìm thấy `redisTemplate` trong class `RedisConfig` và `stringRedisTemplate` trong `RedisAutoConfiguration`